### PR TITLE
Update CLI instructions to install wget

### DIFF
--- a/README.installcli.md
+++ b/README.installcli.md
@@ -15,7 +15,7 @@ Open a terminal on Mac OSX and install the following tools.
 
     ```bash
     brew tap microsoft/mssql-release
-    brew install pwgen ipcalc ttyd tmux mssql-tools mysql-client libpq bash
+    brew install pwgen ipcalc ttyd tmux mssql-tools mysql-client libpq bash wget
     brew link --force libpq
     ```
 3. [Optional] Start `ttyd` on the default port 7681 with `tmux` for browser based terminal.  To test, go to http://localhost:7681


### PR DESCRIPTION
`wget` is not necessarily installed on macOS systems by default and will need to be installed for `02_sqlserver_configure.sh` to run correctly. 

Incidentally, the script continued to execute even though `wget` was not found on my system. Perhaps there's an opportunity to generalize `CONT_OR_EXIT` to be used for any command.